### PR TITLE
Fix 100% CPU usage by removing busy loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"log"
-	"time"
+	"sync"
 
 	"github.com/currantlabs/ble/linux"
 )
@@ -46,10 +46,10 @@ func main() {
 	}
 
 	// Loop forever while notification handler respond
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	for {
-		select {
-		case <-time.After(time.Second):
-		}
+		wg.Wait()
 	}
 
 	// for _, device := range config.Devices {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"runtime"
 
 	"github.com/currantlabs/ble/linux"
 )
@@ -46,6 +47,7 @@ func main() {
 
 	// Loop forever while notification handler respond
 	for {
+		runtime.Gosched()
 	}
 
 	// for _, device := range config.Devices {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"log"
-	"runtime"
+	"time"
 
 	"github.com/currantlabs/ble/linux"
 )
@@ -47,7 +47,9 @@ func main() {
 
 	// Loop forever while notification handler respond
 	for {
-		runtime.Gosched()
+		select {
+		case <-time.After(time.Second):
+		}
 	}
 
 	// for _, device := range config.Devices {


### PR DESCRIPTION
The previous loop was pinning a CPU completely. CPU usage was 100% of a single core.

With this loop though, the Go scheduler knows not to run it all the time. There are a ton of other ways to not have a busy loop, but this seems easiest.